### PR TITLE
fix broken app paths list

### DIFF
--- a/consult-omni.org
+++ b/consult-omni.org
@@ -3280,10 +3280,11 @@ If list is nil, loads `consult-omni-sources-modules-to-load'and if that is nil a
    (setq consult-omni-apps-paths (remove nil (mapcar (lambda (dir)
                                                        (let ((path (and (stringp dir) (file-exists-p dir) (file-truename (expand-file-name "applications" dir)))))
                                                          (and (stringp path) path)))
-                                                     (list consult-omni-apps-xdg-data-home
-                                                           consult-omni-apps-xdg-data-dirs
-                                                           "/usr/share"
-                                                           "/usr/local/share"))))
+                                                     (append
+                                                      consult-omni-apps-xdg-data-dirs
+                                                      '(consult-omni-apps-xdg-data-home
+                                                        "/usr/share"
+                                                        "/usr/local/share")))))
    (setq consult-omni-apps-regexp-pattern ".*\\.desktop$")
    (setq consult-omni-apps-open-command-args "gtk-launch")))
 #+end_src

--- a/sources/consult-omni-apps.el
+++ b/sources/consult-omni-apps.el
@@ -62,10 +62,11 @@
    (setq consult-omni-apps-paths (remove nil (mapcar (lambda (dir)
                                                        (let ((path (and (stringp dir) (file-exists-p dir) (file-truename (expand-file-name "applications" dir)))))
                                                          (and (stringp path) path)))
-                                                     (list consult-omni-apps-xdg-data-home
-                                                           consult-omni-apps-xdg-data-dirs
-                                                           "/usr/share"
-                                                           "/usr/local/share"))))
+                                                     (append
+                                                      consult-omni-apps-xdg-data-dirs
+                                                      '(consult-omni-apps-xdg-data-home
+                                                        "/usr/share"
+                                                        "/usr/local/share")))))
    (setq consult-omni-apps-regexp-pattern ".*\\.desktop$")
    (setq consult-omni-apps-open-command-args "gtk-launch")))
 


### PR DESCRIPTION
The code for detecting app paths on gnu/linux scans this list:
```emacs-lisp
(list consult-omni-apps-xdg-data-home
       consult-omni-apps-xdg-data-dirs
       "/usr/share"
       "/usr/local/share")
```
However, `consult-omni-apps-xdg-data-dirs` is a list itself and not a string, so this will create a list with three strings and one list of strings, which breaks the code and doesn't let any application in `consult-omni-apps-xdg-data-dirs` be launched. To fix this, the three strings must be appended to the `consult-omni-apps-xdg-data-dirs` string.