### PR TITLE
fix broken pipe for some apps

### DIFF
--- a/consult-omni.org
+++ b/consult-omni.org
@@ -3327,7 +3327,8 @@ Uses `consult-omni-apps-open-command-args' as the main command line program
 If FILE is non-nil, returns a command line for opeing the FILE with APP."
   (append (consult--build-args consult-omni-apps-open-command-args)
           (list (format "%s" app))
-          (if (and file (file-exists-p (file-truename file))) (list (format "%s" file)))))
+          (if (and file (file-exists-p (file-truename file))) (list (format "%s" file)))
+          (list "&")))
 #+end_src
 
 ***** make process
@@ -3339,10 +3340,7 @@ Uses `consult-omni--apps-cmd-args' to get the command line args string.
 If FILE is non-nil, the process will open the FILE in APP."
   (let* ((name (concat "consult-omni-" (file-name-base app)))
          (cmds (consult-omni--apps-cmd-args app file)))
-    (make-process :name name
-                :connection-type 'pipe
-                :command cmds
-                :buffer nil)
+    (call-process-shell-command (string-join cmds " "))
     nil))
 #+end_src
 ***** open with

--- a/sources/consult-omni-apps.el
+++ b/sources/consult-omni-apps.el
@@ -82,7 +82,8 @@ Uses `consult-omni-apps-open-command-args' as the main command line program
 If FILE is non-nil, returns a command line for opeing the FILE with APP."
   (append (consult--build-args consult-omni-apps-open-command-args)
           (list (format "%s" app))
-          (if (and file (file-exists-p (file-truename file))) (list (format "%s" file)))))
+          (if (and file (file-exists-p (file-truename file))) (list (format "%s" file)))
+          (list "&")))
 
 (defun consult-omni--apps-launch-app (app &optional file)
   "Makes an async process for opening APP.
@@ -91,10 +92,7 @@ Uses `consult-omni--apps-cmd-args' to get the command line args string.
 If FILE is non-nil, the process will open the FILE in APP."
   (let* ((name (concat "consult-omni-" (file-name-base app)))
          (cmds (consult-omni--apps-cmd-args app file)))
-    (make-process :name name
-                :connection-type 'pipe
-                :command cmds
-                :buffer nil)
+    (call-process-shell-command (string-join cmds " "))
     nil))
 
 (defun consult-omni-open-with-app (&optional file app)


### PR DESCRIPTION
For some apps such as [armcord](https://github.com/ArmCord/ArmCord) it will complain because `make-process` doesn't seem to keep the stdout/stderr open for long enough. This is fixed by using a separate shell process to launch the app (running with "&" attached to make it asynchronous).