### PR TITLE
Fix org-roam and org-headings candidate retrieval in consult-omni sources

### DIFF
--- a/consult-omni.org
+++ b/consult-omni.org
@@ -7088,7 +7088,7 @@ well as the function
   "Preview function for CAND from org-roam files."
   (if cand
       (let* ((title (get-text-property 0 :title cand))
-             (node (org-roam-node-from-title-or-alias title)))
+              (node (get-text-property 0 'node title)))
         (if (org-roam-node-p node)
             (consult--file-action (org-roam-node-file node))))))
 
@@ -7096,7 +7096,7 @@ well as the function
   "Preview function for CAND from org headings."
   (if cand
       (let* ((title (get-text-property 0 :title cand))
-             (marker (get-text-property 0 'consult--candidate title)))
+             (marker (get-text-property 0 'org-marker title)))
         (if marker
             (consult--jump marker)))))
 
@@ -7116,14 +7116,14 @@ well as the function
 (defun consult-omni--consult-notes-org-roam-note-callback (cand &rest _args)
   "Callback function for CAND from org-roam files."
   (let* ((title (get-text-property 0 :title cand))
-         (node (org-roam-node-from-title-or-alias title)))
+         (node (get-text-property 0 'node title)))
     (org-roam-node-open node)))
 
 (defun consult-omni--consult-notes-org-headings-callback (cand &rest _args)
   "Callback function for CAND from org headings."
   (if cand
       (let* ((title (get-text-property 0 :title cand))
-             (marker (get-text-property 0 'consult--candidate title)))
+             (marker (get-text-property 0 'org-marker title)))
         (if marker
             (let* ((buff (marker-buffer marker))
                    (pos (marker-position marker)))

--- a/sources/consult-omni-consult-notes.el
+++ b/sources/consult-omni-consult-notes.el
@@ -32,7 +32,7 @@
   "Preview function for CAND from org-roam files."
   (if cand
       (let* ((title (get-text-property 0 :title cand))
-             (node (org-roam-node-from-title-or-alias title)))
+              (node (get-text-property 0 'node title)))
         (if (org-roam-node-p node)
             (consult--file-action (org-roam-node-file node))))))
 
@@ -40,7 +40,7 @@
   "Preview function for CAND from org headings."
   (if cand
       (let* ((title (get-text-property 0 :title cand))
-             (marker (get-text-property 0 'consult--candidate title)))
+             (marker (get-text-property 0 'org-marker title)))
         (if marker
             (consult--jump marker)))))
 
@@ -56,14 +56,14 @@
 (defun consult-omni--consult-notes-org-roam-note-callback (cand &rest _args)
   "Callback function for CAND from org-roam files."
   (let* ((title (get-text-property 0 :title cand))
-         (node (org-roam-node-from-title-or-alias title)))
+         (node (get-text-property 0 'node title)))
     (org-roam-node-open node)))
 
 (defun consult-omni--consult-notes-org-headings-callback (cand &rest _args)
   "Callback function for CAND from org headings."
   (if cand
       (let* ((title (get-text-property 0 :title cand))
-             (marker (get-text-property 0 'consult--candidate title)))
+             (marker (get-text-property 0 'org-marker title)))
         (if marker
             (let* ((buff (marker-buffer marker))
                    (pos (marker-position marker)))


### PR DESCRIPTION
Fixes #72.  
This pull request modifies the candidate retrieval mechanism for org-roam notes and org headings in the consult-omni-consult-notes source to make it compatible with the latest updates in consult-notes. The key changes involve updating how node and marker properties are accessed:  

1.  For org-roam notes:
2.  Previously: `(org-roam-node-from-title-or-alias title)`
3.  Now: `(get-text-property 0 'node title)`

This change suggests that the node is now pre-computed and stored directly as a text property, which can improve performance and reduce redundant node lookups.  

1.  For org headings:
2.  Previously: `(get-text-property 0 'consult--candidate title)`
3.  Now: `(get-text-property 0 'org-marker title)`

This modification indicates a shift to using the standard Emacs `org-marker` property instead of a custom `consult--candidate` property.  

These changes are applied consistently across two files:  

-   `consult-omni.org`
-   `sources/consult-omni-consult-notes.el`

The modifications affect preview and callback functions for both org-roam notes and org headings, ensuring consistent and more direct property access during candidate selection and navigation.  

Example of the new approach:  

```elisp
(let* ((title (get-text-property 0 :title cand))
       (node (get-text-property 0 'node title)))
  (org-roam-node-open node))
```

The changes should improve the reliability and performance of note and heading retrieval in the consult-omni package.  


## Commit Messages


### (3b8a858)  Fix consult-omni-consult-notes preview, callback

This commit modifies the property retrieval mechanism for org-roam nodes and  
org headings in the consult-omni-consult-notes functionality. The changes  
address how candidate properties are accessed during preview and callback  
operations.  

Key changes:  

-   Replaced \`org-roam-node-from-title-or-alias\` with direct property retrieval
-   Changed property access from 'consult&ndash;candidate' to 'org-marker'
-   Updated property retrieval for 'node' to use direct text property access

Before the change, the code was attempting to retrieve nodes and markers by  
converting titles, which could be less efficient and potentially less reliable.  
Now, the code directly accesses pre-attached text properties, which should  
provide more direct and performant property retrieval.  

Example transformation:  
Old: \`(node (org-roam-node-from-title-or-alias title))\`  
New: \`(node (get-text-property 0 'node title))\`  

This approach assumes that the text properties are correctly set during the  
initial candidate generation, which should improve the overall performance  
and reliability of note and heading selection in the consult-omni  
interface.  

Fixes #72 