### PR TITLE
fix(consult-omni-man): Avoid clobbering consult-omni-mu4e's narrow char

### DIFF
--- a/sources/consult-omni-man.el
+++ b/sources/consult-omni-man.el
@@ -90,7 +90,7 @@ well as the function
 
 ;; Define the man source
 (consult-omni-define-source "man"
-                            :narrow-char ?m
+                            :narrow-char ?M
                             :category 'consult-man
                             :type 'async
                             :require-match t


### PR DESCRIPTION
The `consult-omni-man` and `consult-omni-mu4e` modules both share the same narrow-char. This change uses `M` instead of `m` so they don't collide.