### PR TITLE
Fix consult-omni-buffer compatibility with consult 3.x

### DIFF
--- a/consult-omni.org
+++ b/consult-omni.org
@@ -5378,8 +5378,8 @@ well as the function
 ***** define source
 ****** buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-buffer
+;; make a consult-omni source from `consult-source-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5391,13 +5391,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-buffer)))
 
 #+end_src
 ****** modified buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-modified-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-modified-buffer
+;; make a consult-omni source from `consult-source-modified-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-modified-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5409,13 +5409,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-modified-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-modified-buffer)))
 
 #+end_src
 ****** hidden buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-hidden-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-hidden-buffer
+;; make a consult-omni source from `consult-source-hidden-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-hidden-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5427,13 +5427,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-hidden-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-hidden-buffer)))
 
 #+end_src
 ****** project buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-project-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-project-buffer
+;; make a consult-omni source from `consult-source-project-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-project-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5445,13 +5445,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled :enabled (lambda () (bound-and-true-p consult--source-project-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-buffer)))
 
 #+end_src
 ****** recent file
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-recent-file
+;; make a consult-omni source from `consult-source-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5463,13 +5463,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-recent-file)))
 
 #+end_src
 ****** project recent file
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-project-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-project-recent-file
+;; make a consult-omni source from `consult-source-project-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-project-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5481,13 +5481,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-project-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-recent-file)))
 
 #+end_src
 ****** bookmark
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-bookmark'
-(consult-omni--make-source-from-consult-source 'consult--source-bookmark
+;; make a consult-omni source from `consult-source-bookmark'
+(consult-omni--make-source-from-consult-source 'consult-source-bookmark
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5499,7 +5499,7 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'bookmark-set
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-bookmark)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-bookmark)))
 
 #+end_src
 

--- a/sources/consult-omni-buffer.el
+++ b/sources/consult-omni-buffer.el
@@ -29,8 +29,8 @@
         (when-let ((buff (get-buffer title)))
           (consult--buffer-action buff)))))
 
-;; make a consult-omni source from `consult--source-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-buffer
+;; make a consult-omni source from `consult-source-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -42,10 +42,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-buffer)))
 
-;; make a consult-omni source from `consult--source-modified-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-modified-buffer
+;; make a consult-omni source from `consult-source-modified-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-modified-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -57,10 +57,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-modified-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-modified-buffer)))
 
-;; make a consult-omni source from `consult--source-hidden-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-hidden-buffer
+;; make a consult-omni source from `consult-source-hidden-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-hidden-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -72,10 +72,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-hidden-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-hidden-buffer)))
 
-;; make a consult-omni source from `consult--source-project-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-project-buffer
+;; make a consult-omni source from `consult-source-project-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-project-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -87,10 +87,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled :enabled (lambda () (bound-and-true-p consult--source-project-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-buffer)))
 
-;; make a consult-omni source from `consult--source-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-recent-file
+;; make a consult-omni source from `consult-source-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -102,10 +102,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-recent-file)))
 
-;; make a consult-omni source from `consult--source-project-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-project-recent-file
+;; make a consult-omni source from `consult-source-project-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-project-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -117,10 +117,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-project-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-recent-file)))
 
-;; make a consult-omni source from `consult--source-bookmark'
-(consult-omni--make-source-from-consult-source 'consult--source-bookmark
+;; make a consult-omni source from `consult-source-bookmark'
+(consult-omni--make-source-from-consult-source 'consult-source-bookmark
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -132,7 +132,7 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'bookmark-set
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-bookmark)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-bookmark)))
 
 ;;; provide `consult-omni-buffer' module
 


### PR DESCRIPTION
Consult 3.x made source variables public, renaming consult--source-* to consult-source-*. Update all references in consult-omni-buffer.

Also fix a duplicate :enabled keyword on the project-buffer source.