### PR TITLE
fix: guard against empty sources vector

### DIFF
--- a/consult-omni.el
+++ b/consult-omni.el
@@ -1543,7 +1543,7 @@ Adopted from `consult--multi-lookup'."
                                      sources))
                    ((seq-find (lambda (src) (plist-get src :default)) sources))
                    ((seq-find (lambda (src) (not (plist-get src :hidden))) sources))
-                   ((aref sources 0))))
+                   ((and (> (length sources) 0) (aref sources 0)))))
              (idx (seq-position sources src))
              (def (and (string-blank-p selected) ;; default candidate
                        (seq-find (lambda (cand) (eq idx (consult--tofu-get cand))) candidates))))


### PR DESCRIPTION
Hi sometimes the function consult--multi-lookup give me:

`cond: Args out of range: [], 0`

because it expect at least on source.