### PR TITLE
Update consult source variable names and fix man source narrow character

### DIFF
--- a/consult-omni.org
+++ b/consult-omni.org
@@ -6381,7 +6381,7 @@ well as the function
 #+begin_src emacs-lisp
 ;; Define the man source
 (consult-omni-define-source "man"
-                            :narrow-char ?m
+                            :narrow-char ?M
                             :category 'consult-man
                             :type 'async
                             :require-match t

--- a/consult-omni.org
+++ b/consult-omni.org
@@ -5378,8 +5378,8 @@ well as the function
 ***** define source
 ****** buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-buffer
+;; make a consult-omni source from `consult-source-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5391,13 +5391,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-buffer)))
 
 #+end_src
 ****** modified buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-modified-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-modified-buffer
+;; make a consult-omni source from `consult-source-modified-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-modified-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5409,13 +5409,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-modified-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-modified-buffer)))
 
 #+end_src
 ****** hidden buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-hidden-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-hidden-buffer
+;; make a consult-omni source from `consult-source-hidden-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-hidden-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5427,13 +5427,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-hidden-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-hidden-buffer)))
 
 #+end_src
 ****** project buffer
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-project-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-project-buffer
+;; make a consult-omni source from `consult-source-project-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-project-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5445,13 +5445,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled :enabled (lambda () (bound-and-true-p consult--source-project-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-buffer)))
 
 #+end_src
 ****** recent file
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-recent-file
+;; make a consult-omni source from `consult-source-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5463,13 +5463,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-recent-file)))
 
 #+end_src
 ****** project recent file
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-project-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-project-recent-file
+;; make a consult-omni source from `consult-source-project-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-project-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5481,13 +5481,13 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-project-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-recent-file)))
 
 #+end_src
 ****** bookmark
 #+begin_src emacs-lisp
-;; make a consult-omni source from `consult--source-bookmark'
-(consult-omni--make-source-from-consult-source 'consult--source-bookmark
+;; make a consult-omni source from `consult-source-bookmark'
+(consult-omni--make-source-from-consult-source 'consult-source-bookmark
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -5499,7 +5499,7 @@ well as the function
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'bookmark-set
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-bookmark)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-bookmark)))
 
 #+end_src
 

--- a/sources/consult-omni-buffer.el
+++ b/sources/consult-omni-buffer.el
@@ -29,8 +29,8 @@
         (when-let ((buff (get-buffer title)))
           (consult--buffer-action buff)))))
 
-;; make a consult-omni source from `consult--source-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-buffer
+;; make a consult-omni source from `consult-source-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -42,10 +42,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-buffer)))
 
-;; make a consult-omni source from `consult--source-modified-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-modified-buffer
+;; make a consult-omni source from `consult-source-modified-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-modified-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -57,10 +57,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-modified-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-modified-buffer)))
 
-;; make a consult-omni source from `consult--source-hidden-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-hidden-buffer
+;; make a consult-omni source from `consult-source-hidden-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-hidden-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -72,10 +72,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-hidden-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-hidden-buffer)))
 
-;; make a consult-omni source from `consult--source-project-buffer'
-(consult-omni--make-source-from-consult-source 'consult--source-project-buffer
+;; make a consult-omni source from `consult-source-project-buffer'
+(consult-omni--make-source-from-consult-source 'consult-source-project-buffer
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -87,10 +87,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--buffer-action
                                                :group #'consult-omni--group-function
-                                               :enabled :enabled (lambda () (bound-and-true-p consult--source-project-buffer)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-buffer)))
 
-;; make a consult-omni source from `consult--source-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-recent-file
+;; make a consult-omni source from `consult-source-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -102,10 +102,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-recent-file)))
 
-;; make a consult-omni source from `consult--source-project-recent-file'
-(consult-omni--make-source-from-consult-source 'consult--source-project-recent-file
+;; make a consult-omni source from `consult-source-project-recent-file'
+(consult-omni--make-source-from-consult-source 'consult-source-project-recent-file
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -117,10 +117,10 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'consult--file-action
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-project-recent-file)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-project-recent-file)))
 
-;; make a consult-omni source from `consult--source-bookmark'
-(consult-omni--make-source-from-consult-source 'consult--source-bookmark
+;; make a consult-omni source from `consult-source-bookmark'
+(consult-omni--make-source-from-consult-source 'consult-source-bookmark
                                                :type 'sync
                                                :min-input 0
                                                :on-preview #'consult-omni--consult-buffer-preview
@@ -132,7 +132,7 @@
                                                :preview-key 'consult-omni-preview-key
                                                :on-new #'bookmark-set
                                                :group #'consult-omni--group-function
-                                               :enabled (lambda () (bound-and-true-p consult--source-bookmark)))
+                                               :enabled (lambda () (bound-and-true-p consult-source-bookmark)))
 
 ;;; provide `consult-omni-buffer' module
 

--- a/sources/consult-omni-man.el
+++ b/sources/consult-omni-man.el
@@ -90,7 +90,7 @@ well as the function
 
 ;; Define the man source
 (consult-omni-define-source "man"
-                            :narrow-char ?m
+                            :narrow-char ?M
                             :category 'consult-man
                             :type 'async
                             :require-match t


### PR DESCRIPTION
# Description

This pull request updates the consult-omni project to use the public API for consult source variables instead of private internal variables, and fixes a duplicate keyword issue.  


## Changes Made


### 1. Variable Name Updates (Private to Public API)

All references to private consult source variables (prefixed with `consult--source-`) have been updated to their public counterparts (prefixed with `consult-source-`). This change affects multiple buffer and file sources:  

**Before:**  

```emacs-lisp
(consult-omni--make-source-from-consult-source 'consult--source-buffer
                                               :enabled (lambda () (bound-and-true-p consult--source-buffer)))
```

**After:**  

```emacs-lisp
(consult-omni--make-source-from-consult-source 'consult-source-buffer
                                               :enabled (lambda () (bound-and-true-p consult-source-buffer)))
```

This update applies to the following sources across both `consult-omni-buffer.el` and `consult-omni.org`:  

-   `consult-source-buffer`
-   `consult-source-modified-buffer`
-   `consult-source-hidden-buffer`
-   `consult-source-project-buffer`
-   `consult-source-recent-file`
-   `consult-source-project-recent-file`
-   `consult-source-bookmark`


### 2. Duplicate Keyword Fix

Fixed a duplicate `:enabled` keyword in the project buffer source definition:  

**Before:**  

```emacs-lisp
:enabled :enabled (lambda () (bound-and-true-p consult--source-project-buffer))
```

**After:**  

```emacs-lisp
:enabled (lambda () (bound-and-true-p consult-source-project-buffer))
```


### 3. Man Source Narrow Character Update

Changed the narrow character for the man source from lowercase `?m` to uppercase `?M`:  

**Before:**  

```emacs-lisp
(consult-omni-define-source "man"
                            :narrow-char ?m
```

**After:**  

```emacs-lisp
(consult-omni-define-source "man"
                            :narrow-char ?M
```


## Impact

These changes ensure compatibility with the public consult API, avoiding reliance on private implementation details that may change between versions. The narrow character change prevents potential conflicts with other sources using lowercase `m`.  


# Commit Messages


## (23466ac)  Fix consult-omni-buffer compatibility with consult 3.x

Consult 3.x made source variables public, renaming consult&ndash;source-\*  
to consult-source-\*. Update all references in consult-omni-buffer.  

Also fix a duplicate :enabled keyword on the project-buffer source.  


## (ac7d4b7)  Merge pull request #78 from Gleek/develop

Fix consult-omni-buffer compatibility with consult 3.x  


## (961f95a)  Change man source narrow char to uppercase M

Fixes #76  
The narrow character for the man source in consult-omni  
has been changed from lowercase 'm' to uppercase 'M'.  
This change improves consistency with common naming  
conventions and makes the narrow character more visually  
distinct in the UI.  

This modification affects both the documentation file  
(consult-omni.org) and the source implementation file  
(sources/consult-omni-man.el) to keep them in sync.  

When users filter sources in consult-omni, they can now  
use 'M' to narrow results to man pages instead of 'm'.