### PR TITLE
Add GPL-3.0-or-later License Headers to All Source Files* Add GPL-3.0-or-later License Headers to All Source Files

### DIFF
--- a/consult-omni-embark.el
+++ b/consult-omni-embark.el
@@ -15,6 +15,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; provides Embark actions for consult-omni
 ;;; Code:

--- a/consult-omni.el
+++ b/consult-omni.el
@@ -13,6 +13,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni is a package for getting search results from one or
 ;; several custom sources (web search engines, AI assistants,

--- a/consult-omni.org
+++ b/consult-omni.org
@@ -20,6 +20,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni is a package for getting search results from one or
 ;; several custom sources (web search engines, AI assistants,
@@ -3052,6 +3068,22 @@ ARGS."
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; provides Embark actions for consult-omni
 ;;; Code:
@@ -3661,6 +3693,22 @@ Can be:
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; This file provides the default sources for consult-omni.
 
@@ -3763,6 +3811,22 @@ is nil as well, loads `consult-omni-sources--all-modules-list'."
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 
 ;;; Commentary:
 ;; consult-omni-apps provides commands for searching desktop applications using consult-omni.
@@ -4203,6 +4267,22 @@ to update list of candidates in the minibuffer."
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-bing provides commands for searching bing in Emacs using ;; consult-omni.
 
@@ -4347,6 +4427,22 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-brave provides commands for searching Brave in Emacs using
 ;; consult-omni.
@@ -4489,6 +4585,22 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 
 ;;; Commentary:
 ;; consult-omni-brave-autosuggest provides commands for getting
@@ -4648,6 +4760,22 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-browser-history provides commands for searching browser
 ;; history in Emacs using consult-omni.  It uses the browser-hist.el
@@ -4780,6 +4908,22 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 
 ;;; Commentary:
 ;; consult-omni-calc provides commands for getting calc results directly
@@ -5013,6 +5157,22 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-chatgpt provides commands for getting ChatGPT results
 ;; directly in the minibuffer using consult-omni.
@@ -5208,6 +5368,22 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-line-multi provides commands for searching lines in
 ;; multiple buffers similar to consult-line-multi but using consult-omni.
@@ -5354,6 +5530,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-buffer provides commands for searching buffer names
@@ -5537,6 +5728,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-fd provides commands for running “fd” shell commands
 ;; similar to consult-fd but using consult-omni.
@@ -5682,6 +5888,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-find provides commands for running “find” shell commands
@@ -5833,6 +6054,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-git-grep provides commands for running “git grep” shell
 ;; commands similar to consult-git-grep but using consult-omni.
@@ -5931,6 +6167,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-grep provides commands for running “grep” shell commands
@@ -6123,6 +6374,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-locate provides commands for running “locate” shell
 ;; commands similar to consult-locate but using consult-omni.
@@ -6278,6 +6544,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-man provides commands for running “man” shell commands
@@ -6436,6 +6717,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-mdfind provides commands for running “mdfind” shell
 ;; commands
@@ -6566,6 +6862,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-ripgrep provides commands for running “rg” shell commands
 ;; similar to consult-ripgrep but using consult-omni.
@@ -6664,6 +6975,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-ripgrep-all provides commands for running “rga” shell
@@ -6890,6 +7216,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-consult-notes enables using consult-notes in consult-omni.
 ;; It provides commands to search note files using consult-notes the
@@ -7093,6 +7434,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-gh enables using consult-gh in consult-omni.
 ;; It provides commands to search GitHub repositories using consult-gh as ;; the backend.
@@ -7235,6 +7591,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-mu4e enables searching emails in consult-omni.
@@ -7415,6 +7786,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-dict enables searching in the dictionary with
@@ -7780,6 +8166,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-doi enables looking up DOIs in consult-omni.
 ;; It provides commands to search DOIs using DOI.org as the backend.
@@ -7914,6 +8315,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-duckduckgo provides commands for searching DuckDuckGo's
 ;; “limited” API in Emacs using consult-omni.
@@ -8036,6 +8452,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni/blob/main/consult-omni-sources
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-elfeed enables searching Elfeed's feeds in consult-omni.
@@ -8253,6 +8684,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-google provides commands for searching Goggle in Emacs
 ;; using consult-omni.
@@ -8424,6 +8870,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-google-autosuggest provides commands for getting
 ;; autosuggestion from Google in Emacs using consult-omni.
@@ -8548,6 +9009,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-gptel enables searching LLMS in consult-omni using gptel.
@@ -8903,6 +9379,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-invidious provides commands for searching Invidious in Emacs
 ;; using consult-omni.
@@ -9178,6 +9669,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-notes enables searching note files in consult-omni.
 ;; It provides commands to search notes using grep-like process (e.g. grep, ;; ripgrep, ...) and getting the results directly in the minibuffer.
@@ -9395,6 +9901,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-notmuch enables searching notmuch emails in consult-omni.
@@ -9732,6 +10253,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-numi provides commands for doing calculations directly in
 ;; Emacs minibuffer using consult-omni as the frontend and numi-cli shell
@@ -9913,6 +10449,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-openalex provides commands for searching OpenAlex database
@@ -10644,6 +11195,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-org-agenda enables searching `org-agenda' directly in Emacs ;; minibuffer using consult-omni.  It provides commands to search aegnda
 ;; items and see relevant items in the minibuffer and has support for
@@ -11163,6 +11729,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-projects enables searching projects directly in Emacs
 ;; minibuffer using consult-omni.  It uses projects.el as the backend
@@ -11505,6 +12086,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-projects enables searching projects directly in Emacs
 ;; minibuffer using consult-omni.  It uses projects.el as the backend
@@ -11829,6 +12425,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-pubmed provides commands for searching PubMed database
 ;; directly in Emacs using consult-omni as the frontend.
@@ -12112,6 +12723,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-scopus provides commands for searching Scopus database
 ;; directly in Emacs using consult-omni as the frontend.
@@ -12344,6 +12970,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-stackoverflow provides commands for searching StackOverflow
 ;; directly in Emacs using consult-omni as the frontend.
@@ -12546,6 +13187,21 @@ well as the function
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-wikipedia provides commands for searching Wikipedia in
 ;; Emacs using consult-omni as the frontend.
@@ -12717,6 +13373,21 @@ well as the function
 ;;
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;; consult-omni-youtube provides commands for searching YouTube in Emacs

--- a/sources/consult-omni-apps.el
+++ b/sources/consult-omni-apps.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-apps provides commands for searching desktop applications using consult-omni.
 

--- a/sources/consult-omni-bing.el
+++ b/sources/consult-omni-bing.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-bing provides commands for searching bing in Emacs using ;; consult-omni.
 

--- a/sources/consult-omni-brave-autosuggest.el
+++ b/sources/consult-omni-brave-autosuggest.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-brave-autosuggest provides commands for getting
 ;; autosuggestion from Brave in Emacs using consult-omni.

--- a/sources/consult-omni-brave.el
+++ b/sources/consult-omni-brave.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-brave provides commands for searching Brave in Emacs using
 ;; consult-omni.

--- a/sources/consult-omni-browser-history.el
+++ b/sources/consult-omni-browser-history.el
@@ -15,6 +15,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-browser-history provides commands for searching browser
 ;; history in Emacs using consult-omni.  It uses the browser-hist.el

--- a/sources/consult-omni-buffer.el
+++ b/sources/consult-omni-buffer.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-buffer provides commands for searching buffer names
 ;; similar to consult-buffer but using consult-omni.

--- a/sources/consult-omni-calc.el
+++ b/sources/consult-omni-calc.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-calc provides commands for getting calc results directly
 ;; in the minibuffer using consult-omni.

--- a/sources/consult-omni-chatgpt.el
+++ b/sources/consult-omni-chatgpt.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-chatgpt provides commands for getting ChatGPT results
 ;; directly in the minibuffer using consult-omni.

--- a/sources/consult-omni-consult-notes.el
+++ b/sources/consult-omni-consult-notes.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-consult-notes enables using consult-notes in consult-omni.
 ;; It provides commands to search note files using consult-notes the

--- a/sources/consult-omni-dict.el
+++ b/sources/consult-omni-dict.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-dict enables searching in the dictionary with
 ;; consult-omni.  It provides commands to search Emacs's built-in

--- a/sources/consult-omni-doi.el
+++ b/sources/consult-omni-doi.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-doi enables looking up DOIs in consult-omni.
 ;; It provides commands to search DOIs using DOI.org as the backend.

--- a/sources/consult-omni-duckduckgo.el
+++ b/sources/consult-omni-duckduckgo.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-duckduckgo provides commands for searching DuckDuckGo's
 ;; “limited” API in Emacs using consult-omni.

--- a/sources/consult-omni-elfeed.el
+++ b/sources/consult-omni-elfeed.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni/blob/main/consult-omni-sources
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-elfeed enables searching Elfeed's feeds in consult-omni.
 ;; It provides commands to search feeds and getting the results

--- a/sources/consult-omni-fd.el
+++ b/sources/consult-omni-fd.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-fd provides commands for running “fd” shell commands
 ;; similar to consult-fd but using consult-omni.

--- a/sources/consult-omni-find.el
+++ b/sources/consult-omni-find.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-find provides commands for running “find” shell commands
 ;; similar to consult-find but using consult-omni.

--- a/sources/consult-omni-gh.el
+++ b/sources/consult-omni-gh.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-gh enables using consult-gh in consult-omni.
 ;; It provides commands to search GitHub repositories using consult-gh as ;; the backend.

--- a/sources/consult-omni-git-grep.el
+++ b/sources/consult-omni-git-grep.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-git-grep provides commands for running “git grep” shell
 ;; commands similar to consult-git-grep but using consult-omni.

--- a/sources/consult-omni-google-autosuggest.el
+++ b/sources/consult-omni-google-autosuggest.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-google-autosuggest provides commands for getting
 ;; autosuggestion from Google in Emacs using consult-omni.

--- a/sources/consult-omni-google.el
+++ b/sources/consult-omni-google.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-google provides commands for searching Goggle in Emacs
 ;; using consult-omni.

--- a/sources/consult-omni-gptel.el
+++ b/sources/consult-omni-gptel.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-gptel enables searching LLMS in consult-omni using gptel.
 ;; It provides commands to get gptel results directly in the minibuffer.

--- a/sources/consult-omni-grep.el
+++ b/sources/consult-omni-grep.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-grep provides commands for running “grep” shell commands
 ;; similar to consult-grep but using consult-omni.

--- a/sources/consult-omni-invidious.el
+++ b/sources/consult-omni-invidious.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-invidious provides commands for searching Invidious in Emacs
 ;; using consult-omni.

--- a/sources/consult-omni-line-multi.el
+++ b/sources/consult-omni-line-multi.el
@@ -13,6 +13,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; consult-omni-line-multi provides commands for searching lines in
 ;; multiple buffers similar to consult-line-multi but using consult-omni.

--- a/sources/consult-omni-locate.el
+++ b/sources/consult-omni-locate.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-locate provides commands for running “locate” shell
 ;; commands similar to consult-locate but using consult-omni.

--- a/sources/consult-omni-man.el
+++ b/sources/consult-omni-man.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-man provides commands for running “man” shell commands
 ;; similar to consult-man but using consult-omni.

--- a/sources/consult-omni-mdfind.el
+++ b/sources/consult-omni-mdfind.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-mdfind provides commands for running “mdfind” shell
 ;; commands

--- a/sources/consult-omni-mu4e.el
+++ b/sources/consult-omni-mu4e.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-mu4e enables searching emails in consult-omni.
 ;; It provides commands to search emails using consult-mu as the backend.

--- a/sources/consult-omni-notes.el
+++ b/sources/consult-omni-notes.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-notes enables searching note files in consult-omni.
 ;; It provides commands to search notes using grep-like process (e.g. grep, ;; ripgrep, ...) and getting the results directly in the minibuffer.

--- a/sources/consult-omni-notmuch.el
+++ b/sources/consult-omni-notmuch.el
@@ -15,6 +15,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-notmuch enables searching notmuch emails in consult-omni.
 ;; It provides commands to search emails and getting the results

--- a/sources/consult-omni-numi.el
+++ b/sources/consult-omni-numi.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-numi provides commands for doing calculations directly in
 ;; Emacs minibuffer using consult-omni as the frontend and numi-cli shell

--- a/sources/consult-omni-openalex.el
+++ b/sources/consult-omni-openalex.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-openalex provides commands for searching OpenAlex database
 ;; directly in Emacs using consult-omni as the frontend.

--- a/sources/consult-omni-org-agenda.el
+++ b/sources/consult-omni-org-agenda.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-org-agenda enables searching `org-agenda' directly in Emacs ;; minibuffer using consult-omni.  It provides commands to search aegnda
 ;; items and see relevant items in the minibuffer and has support for

--- a/sources/consult-omni-process.el
+++ b/sources/consult-omni-process.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-projects enables searching projects directly in Emacs
 ;; minibuffer using consult-omni.  It uses projects.el as the backend

--- a/sources/consult-omni-projects.el
+++ b/sources/consult-omni-projects.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-projects enables searching projects directly in Emacs
 ;; minibuffer using consult-omni.  It uses projects.el as the backend

--- a/sources/consult-omni-pubmed.el
+++ b/sources/consult-omni-pubmed.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-pubmed provides commands for searching PubMed database
 ;; directly in Emacs using consult-omni as the frontend.

--- a/sources/consult-omni-ripgrep-all.el
+++ b/sources/consult-omni-ripgrep-all.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-ripgrep-all provides commands for running “rga” shell
 ;; commands.

--- a/sources/consult-omni-ripgrep.el
+++ b/sources/consult-omni-ripgrep.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-ripgrep provides commands for running “rg” shell commands
 ;; similar to consult-ripgrep but using consult-omni.

--- a/sources/consult-omni-scopus.el
+++ b/sources/consult-omni-scopus.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-scopus provides commands for searching Scopus database
 ;; directly in Emacs using consult-omni as the frontend.

--- a/sources/consult-omni-sources.el
+++ b/sources/consult-omni-sources.el
@@ -14,6 +14,22 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+
 ;;; Commentary:
 ;; This file provides the default sources for consult-omni.
 

--- a/sources/consult-omni-stackoverflow.el
+++ b/sources/consult-omni-stackoverflow.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-stackoverflow provides commands for searching StackOverflow
 ;; directly in Emacs using consult-omni as the frontend.

--- a/sources/consult-omni-wikipedia.el
+++ b/sources/consult-omni-wikipedia.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-wikipedia provides commands for searching Wikipedia in
 ;; Emacs using consult-omni as the frontend.

--- a/sources/consult-omni-youtube.el
+++ b/sources/consult-omni-youtube.el
@@ -14,6 +14,21 @@
 ;; Homepage: https://github.com/armindarvish/consult-omni
 ;; Keywords: convenience
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;; consult-omni-youtube provides commands for searching YouTube in Emacs
 ;; using consult-omni as the frontend.


### PR DESCRIPTION
# Description

This pull request adds comprehensive GPL-3.0-or-later license headers to all source files in the consult-omni project. The changes ensure proper legal compliance and clarify the licensing terms for all code.  


## What Changed

Every Emacs Lisp source file and the org-mode documentation file now includes:  

1.  **SPDX License Identifier**: A standardized `SPDX-License-Identifier: GPL-3.0-or-later` tag for machine-readable license detection
2.  **Full License Text**: A complete GPL-3.0-or-later license notice explaining:  
    -   The file is free software that can be redistributed and modified
    -   Terms under GNU General Public License version 3 or later
    -   Warranty disclaimer
    -   Reference to the full license at <https://www.gnu.org/licenses/>


## Files Modified

The license headers were added to:  

-   **Main files**: `consult-omni.el`, `consult-omni-embark.el`, `consult-omni.org`
-   **Source modules** (in `sources/` directory): 40+ individual source files including:  
    -   Search engines: `consult-omni-google.el`, `consult-omni-bing.el`, `consult-omni-brave.el`, `consult-omni-duckduckgo.el`
    -   Academic databases: `consult-omni-pubmed.el`, `consult-omni-openalex.el`, `consult-omni-scopus.el`
    -   System tools: `consult-omni-ripgrep.el`, `consult-omni-grep.el`, `consult-omni-find.el`, `consult-omni-locate.el`
    -   AI/LLM integrations: `consult-omni-chatgpt.el`, `consult-omni-gptel.el`
    -   And many more specialized modules


## License Header Format

Each file now includes this standard header after the file metadata:  

```elisp
;; SPDX-License-Identifier: GPL-3.0-or-later

;; This file is free software: you can redistribute it and/or modify
;; it under the terms of the GNU General Public License as published
;; by the Free Software Foundation, either version 3 of the License,
;; or (at your option) any later version.
;;
;; This file is distributed in the hope that it will be useful,
;; but WITHOUT ANY WARRANTY; without even the implied warranty of
;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
;; GNU General Public License for more details.
;;
;; You should have received a copy of the GNU General Public License
;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
```


## Benefits

-   **Legal Clarity**: Users and contributors understand the licensing terms
-   **Machine Readability**: SPDX identifiers enable automated license compliance checking
-   **Standards Compliance**: Follows best practices for open-source projects
-   **Consistency**: All files now have uniform license declarations


## No Functional Changes

This is a documentation-only change. No code logic, functionality, or behavior has been modified. All changes are purely additive license header insertions.  


# Commit Messages


## (e51ac41)  Add GPL-3.0-or-later license headers

Fixes #77  

This commit adds comprehensive GPL-3.0-or-later license  
headers to all source files in the consult-omni project.  
Each file now includes:  

-   SPDX-License-Identifier tag for machine-readable  
    license identification
-   Full GPL-3.0-or-later license text explaining the  
    terms of redistribution and modification
-   Warranty disclaimer and reference to the full license

The license headers are placed after the file metadata  
(author, version, homepage) and before the commentary  
section, following standard Emacs Lisp conventions.  

This change applies to:  

-   Main package files (consult-omni.el, consult-omni.org)
-   Integration modules (consult-omni-embark.el)
-   All source modules in the sources/ directory covering  
    search backends (Google, Wikipedia, GitHub, etc.),  
    local tools (ripgrep, find, locate), and integrations  
    (elfeed, mu4e, notmuch, org-agenda, etc.)

The addition of explicit license headers improves legal  
clarity and makes the project's open-source nature more  
transparent to users and contributors.