### PR TITLE
Fix =if-let*= binding syntax in =consult-omni-embark.el= and =consult-omni.org=

### DIFF
--- a/consult-omni-embark.el
+++ b/consult-omni-embark.el
@@ -339,7 +339,7 @@ Uses `consult-omni-embark-scholar-make-note-func' to make template."
 
 (defun consult-omni-embark-calc-insert-results (cand)
   "Insert the results of the calculator, CAND, at point."
-  (if-let* (results (and (stringp cand) (get-text-property 0 :title cand)))
+  (if-let* ((results (and (stringp cand) (get-text-property 0 :title cand))))
       (insert (format " %s " results))))
 
 (defun consult-omni-embark-calc-copy-formula-as-kill (cand)
@@ -349,7 +349,7 @@ Uses `consult-omni-embark-scholar-make-note-func' to make template."
 
 (defun consult-omni-embark-calc-insert-formula (cand)
   "Insert the results of the calculator, CAND, at point."
-  (if-let* (formula (and (stringp cand) (get-text-property 0 :query cand)))
+  (if-let* ((formula (and (stringp cand) (get-text-property 0 :query cand))))
       (insert (format " %s " formula))))
 
 ;;; Define Embark Keymaps

--- a/consult-omni.org
+++ b/consult-omni.org
@@ -3431,7 +3431,7 @@ Uses `consult-omni-embark-scholar-make-note-func' to make template."
 
 (defun consult-omni-embark-calc-insert-results (cand)
   "Insert the results of the calculator, CAND, at point."
-  (if-let* (results (and (stringp cand) (get-text-property 0 :title cand)))
+  (if-let* ((results (and (stringp cand) (get-text-property 0 :title cand))))
       (insert (format " %s " results))))
 
 (defun consult-omni-embark-calc-copy-formula-as-kill (cand)
@@ -3441,7 +3441,7 @@ Uses `consult-omni-embark-scholar-make-note-func' to make template."
 
 (defun consult-omni-embark-calc-insert-formula (cand)
   "Insert the results of the calculator, CAND, at point."
-  (if-let* (formula (and (stringp cand) (get-text-property 0 :query cand)))
+  (if-let* ((formula (and (stringp cand) (get-text-property 0 :query cand))))
       (insert (format " %s " formula))))
 
 #+end_src


### PR DESCRIPTION
# Description

This pull request fixes a subtle but important syntax bug in the `if-let*`  
macro usage within two functions in `consult-omni-embark.el` (and its  
corresponding literate programming source in `consult-omni.org`).  


## Problem

The `if-let*` macro in Emacs Lisp requires its bindings to be wrapped in  
an outer list of binding pairs, where each binding pair is itself a list  
of the form `(variable value)`. The previous code was missing the outer  
parentheses around the binding pairs, causing incorrect behavior.  

**Incorrect syntax (before):**  

```elisp
(if-let* (results (and (stringp cand) (get-text-property 0 :title cand)))
    (insert (format " %s " results)))
```

In this form, `if-let*` interprets `results` as a binding spec (a single  
symbol, which is valid but binds `results` to itself, i.e., non-nil), and  
the `(and ...)` form as the "then" branch, completely ignoring the intended  
logic. This means the function would never correctly bind `results` to the  
text property value, and the `insert` call would never execute as intended.  

**Correct syntax (after):**  

```elisp
(if-let* ((results (and (stringp cand) (get-text-property 0 :title cand))))
    (insert (format " %s " results)))
```

Here, `if-let*` receives a proper list of binding pairs: one pair  
`(results <value>)`. If the value is non-nil, `results` is bound to it  
and the `insert` form executes. If the value is nil (e.g., `cand` is not  
a string or has no `:title` property), the body is skipped entirely.  


## Affected Functions

1.  **`consult-omni-embark-calc-insert-results`** — Inserts the calculator  
    result (stored in the `:title` text property of `cand`) at point.

2.  **`consult-omni-embark-calc-insert-formula`** — Inserts the calculator  
    formula (stored in the `:query` text property of `cand`) at point.


## Files Changed

-   `consult-omni-embark.el` — The actual Emacs Lisp source file.
-   `consult-omni.org` — The literate programming org-mode source that  
    generates the `.el` file, kept in sync with the same fix.


## Example

Given a candidate string `cand` with text properties:  

```elisp
(propertize "42" :title "6 * 7 = 42" :query "6 * 7")
```

**Before the fix**, calling `consult-omni-embark-calc-insert-results`  
would silently do nothing useful due to the malformed `if-let*` binding.  

**After the fix**, it correctly inserts = 6 \* 7 = 42 = at point when  
`cand` is a valid string with a `:title` property.  


# Commit Messages


## (899bcdd)  Fix `if-let*` binding syntax in embark calc

Correct malformed `if-let*` variable binding expressions in  
`consult-omni-embark-calc-insert-results` and  
`consult-omni-embark-calc-insert-formula` functions, in both  
`consult-omni-embark.el` and `consult-omni.org`.  

The `if-let*` macro requires its bindings to be wrapped in an  
outer list, where each binding is itself a list of the form  
`(VAR EXPR)`. The previous code was missing the outer  
parentheses around each binding, causing incorrect behavior or  
errors at runtime.  

Incorrect form:  
  (if-let\* (results (and (stringp cand)  
                         (get-text-property 0 :title cand)))  
    &hellip;)  

Correct form:  
  (if-let\* ((results (and (stringp cand)  
                          (get-text-property 0 :title cand))))  
    &hellip;)  

Without the extra parentheses, `if-let*` would interpret  
`results` as a binding with no value expression, and the  
`(and ...)` form as a separate, unrelated binding, leading to  
unexpected behavior rather than the intended conditional  
binding and insertion logic.  

The same fix is applied symmetrically to both the tangled  
Elisp source file and the corresponding Org literate source  
block to keep them in sync.