### PR TITLE
Fix: Prepend split-style character to thingatpt results consistently

### DIFF
--- a/consult-omni.el
+++ b/consult-omni.el
@@ -1169,7 +1169,9 @@ the history in consul-omni's minibuffer completion."
         (cl-remove-duplicates
          (append
           (when (region-active-p) (list (concat (consult-omni--get-split-style-character) (buffer-substring (region-beginning) (region-end)))))
-          (mapcar (lambda (thing) (consult-omni-dynamic--split-thingatpt thing))
+          (mapcar (lambda (thing) (let* ((str (consult-omni-dynamic--split-thingatpt thing)))
+                                    (when (stringp str)
+                                      (concat (consult-omni--get-split-style-character) str))))
                   (or things (list 'number 'word 'sexp 'symbol 'url 'filename 'sentence 'line)))
           (when (and isearch-string (not (string-empty-p isearch-string))) (list (concat (consult-omni--get-split-style-character) isearch-string)))))))
 

--- a/consult-omni.org
+++ b/consult-omni.org
@@ -1340,7 +1340,9 @@ the history in consul-omni's minibuffer completion."
         (cl-remove-duplicates
          (append
           (when (region-active-p) (list (concat (consult-omni--get-split-style-character) (buffer-substring (region-beginning) (region-end)))))
-          (mapcar (lambda (thing) (consult-omni-dynamic--split-thingatpt thing))
+          (mapcar (lambda (thing) (let* ((str (consult-omni-dynamic--split-thingatpt thing)))
+                                    (when (stringp str)
+                                      (concat (consult-omni--get-split-style-character) str))))
                   (or things (list 'number 'word 'sexp 'symbol 'url 'filename 'sentence 'line)))
           (when (and isearch-string (not (string-empty-p isearch-string))) (list (concat (consult-omni--get-split-style-character) isearch-string)))))))
 


### PR DESCRIPTION
# Description


## Problem

Previously, the `consult-omni-dynamic--split-thingatpt` function was called  
directly inside `mapcar` without any post-processing of its return value. This  
meant that the split-style character (used as a delimiter/prefix in  
consult-omni's query syntax) was not being prepended to the results returned  
by `thingatpt`, unlike how other query sources (region text and isearch string)  
were handled.  

Additionally, `consult-omni-dynamic--split-thingatpt` can return `nil` when no  
"thing" is found at point for a given type. Without a type check, `nil` values  
would be passed to `concat`, causing errors or unexpected behavior.  


## Root Cause

The original code:  

```elisp
(mapcar (lambda (thing) (consult-omni-dynamic--split-thingatpt thing))
        (or things (list 'number 'word 'sexp 'symbol 'url 'filename 'sentence 'line)))
```

Had two issues:  

1.  It did not prepend the split-style character to the result of  
    `consult-omni-dynamic--split-thingatpt`, making these results inconsistent  
    with the region and isearch string entries.
2.  It did not guard against `nil` return values from  
    `consult-omni-dynamic--split-thingatpt`.


## Fix

The updated code:  

```elisp
(mapcar (lambda (thing) (let* ((str (consult-omni-dynamic--split-thingatpt thing)))
                          (when (stringp str)
                            (concat (consult-omni--get-split-style-character) str))))
        (or things (list 'number 'word 'sexp 'symbol 'url 'filename 'sentence 'line)))
```

1.  Captures the result of `consult-omni-dynamic--split-thingatpt` into `str`.
2.  Checks if `str` is actually a string using `(stringp str)` before  
    proceeding, safely handling `nil` or unexpected return values.
3.  Prepends the split-style character via  
    `(consult-omni--get-split-style-character)` to ensure consistency with how  
    region text and isearch strings are formatted.


## Example

Suppose the split-style character is `#` and the word at point is `"emacs"`.  

**Before the fix:**  

-   The `mapcar` would return `"emacs"` without the prefix character.
-   Region text would return `"#emacs"` (with the prefix).
-   This inconsistency could cause incorrect query parsing.

**After the fix:**  

-   The `mapcar` now returns `"#emacs"`, consistent with region and isearch  
    string handling.
-   If no thing is found at point, `nil` is returned safely and later filtered  
    out by `cl-remove-duplicates` and `append`.


## Files Changed

-   `consult-omni.el`: Core Elisp implementation updated.
-   `consult-omni.org`: Literate programming source document updated to match.


# Commit Messages


## (473d877)  Fix nil values in thingatpt split results

Previously, \`consult-omni-dynamic&ndash;split-thingatpt\` was called  
directly inside \`mapcar\` without checking whether the return  
value was a valid string. If the function returned nil (e.g.,  
when no valid "thing" was found at point for a given type like  
'number or 'url), the nil value would be included as-is in the  
resulting list passed to \`cl-remove-duplicates\` and \`append\`.  

This could cause unexpected behavior downstream, as consumers  
of this list would encounter nil entries mixed in with valid  
query strings.  

The fix wraps the call in a \`let\*\` binding and adds an explicit  
\`stringp\` check before prepending the split-style character:  

Before:  
  (mapcar (lambda (thing)  
            (consult-omni-dynamic&ndash;split-thingatpt thing))  
          &hellip;)  

After:  
  (mapcar (lambda (thing)  
            (let\* ((str (consult-omni-dynamic&ndash;split-thingatpt  
                         thing)))  
              (when (stringp str)  
                (concat  
                 (consult-omni&ndash;get-split-style-character)  
                 str))))  
          &hellip;)  

This ensures that only valid string results are included in the  
candidate list, and nil values from unmatched thing types are  
filtered out naturally (as \`when\` returns nil, which \`append\`  
and \`cl-remove-duplicates\` handle gracefully).  

The same fix is applied consistently in both \`consult-omni.el\`  
and the corresponding documentation in \`consult-omni.org\`.